### PR TITLE
Rename the hidedevtools and devtoolsheight params to lowercase

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
 
+- fix: changed the case of the URL query parameters for the `hideDevTools` and `devToolsHeight` options, for backwards compatibility with StackBlitz EE (https://github.com/stackblitz/sdk/pull/1)
 - chore: moved the SDK’s repository to https://github.com/stackblitz/sdk
 - chore: switched the SDK’s build tool from microbundle to Vite
 

--- a/src/params.ts
+++ b/src/params.ts
@@ -2,11 +2,34 @@ import type { EmbedOptions, OpenOptions } from './interfaces';
 
 type Options = Omit<OpenOptions & EmbedOptions, 'origin' | 'newWindow' | 'height' | 'width'>;
 
+/**
+ * URL parameter names supported by the StackBlitz instance.
+ * Note that while updated instances perform a case-insensitive lookup
+ * for query parameters, some Enterprise Edition deployments may not,
+ * and we need to use specific (and sometimes inconsistent) casing;
+ * see for example 'hidedevtools' vs 'hideNavigation'.
+ */
+type ParamName =
+  | '_test'
+  | 'clicktoload'
+  | 'ctl'
+  | 'devtoolsheight'
+  | 'embed'
+  | 'file'
+  | 'hidedevtools'
+  | 'hideExplorer'
+  | 'hideNavigation'
+  | 'initialpath'
+  | 'showSidebar'
+  | 'terminalHeight'
+  | 'theme'
+  | 'view';
+
 const generators: Record<keyof Options, (value: any) => string> = {
   clickToLoad: (value: Options['clickToLoad']) => trueParam('ctl', value),
-  devToolsHeight: (value: Options['devToolsHeight']) => percentParam('devToolsHeight', value),
+  devToolsHeight: (value: Options['devToolsHeight']) => percentParam('devtoolsheight', value),
   forceEmbedLayout: (value: Options['forceEmbedLayout']) => trueParam('embed', value),
-  hideDevTools: (value: Options['hideDevTools']) => trueParam('hideDevTools', value),
+  hideDevTools: (value: Options['hideDevTools']) => trueParam('hidedevtools', value),
   hideExplorer: (value: Options['hideExplorer']) => trueParam('hideExplorer', value),
   hideNavigation: (value: Options['hideNavigation']) => trueParam('hideNavigation', value),
   showSidebar: (value: Options['showSidebar']) => booleanParam('showSidebar', value),
@@ -29,21 +52,21 @@ export function buildParams(options: Options = {}): string {
   return params.length ? `?${params.join('&')}` : '';
 }
 
-export function trueParam(name: string, value?: boolean): string {
+export function trueParam(name: ParamName, value?: boolean): string {
   if (value === true) {
     return `${name}=1`;
   }
   return '';
 }
 
-export function booleanParam(name: string, value?: boolean): string {
+export function booleanParam(name: ParamName, value?: boolean): string {
   if (typeof value === 'boolean') {
     return `${name}=${value ? '1' : '0'}`;
   }
   return '';
 }
 
-export function percentParam(name: string, value?: number): string {
+export function percentParam(name: ParamName, value?: number): string {
   if (typeof value === 'number' && !Number.isNaN(value)) {
     const clamped = Math.min(100, Math.max(0, value));
     return `${name}=${Math.round(clamped)}`;
@@ -51,14 +74,14 @@ export function percentParam(name: string, value?: number): string {
   return '';
 }
 
-export function enumParam(name: string, oneOf: string[], value?: string) {
+export function enumParam(name: ParamName, oneOf: string[], value?: string) {
   if (typeof value === 'string' && oneOf.includes(value)) {
     return `${name}=${value}`;
   }
   return '';
 }
 
-export function stringParams(name: string, value?: string | string[]): string[] {
+export function stringParams(name: ParamName, value?: string | string[]): string[] {
   const values = Array.isArray(value) ? value : [value];
   return values
     .filter((val) => typeof val === 'string' && val.trim() !== '')

--- a/test/params.spec.ts
+++ b/test/params.spec.ts
@@ -11,52 +11,52 @@ import {
 
 describe('params formats', () => {
   test('trueParam accepts true only', () => {
-    expect(trueParam('test')).toBe('');
-    expect(trueParam('test', 1 as any)).toBe('');
-    expect(trueParam('test', false)).toBe('');
-    expect(trueParam('test', true)).toBe('test=1');
+    expect(trueParam('_test')).toBe('');
+    expect(trueParam('_test', 1 as any)).toBe('');
+    expect(trueParam('_test', false)).toBe('');
+    expect(trueParam('_test', true)).toBe('_test=1');
   });
 
   test('booleanParam accepts true and false', () => {
-    expect(booleanParam('test')).toBe('');
-    expect(booleanParam('test', 'yes' as any)).toBe('');
-    expect(booleanParam('test', false)).toBe('test=0');
-    expect(booleanParam('test', true)).toBe('test=1');
+    expect(booleanParam('_test')).toBe('');
+    expect(booleanParam('_test', 'yes' as any)).toBe('');
+    expect(booleanParam('_test', false)).toBe('_test=0');
+    expect(booleanParam('_test', true)).toBe('_test=1');
   });
 
   test('percentParam clamps and rounds number values', () => {
-    expect(percentParam('test')).toBe('');
-    expect(percentParam('test', '50%' as any)).toBe('');
-    expect(percentParam('test', 0 / 0)).toBe('');
+    expect(percentParam('_test')).toBe('');
+    expect(percentParam('_test', '50%' as any)).toBe('');
+    expect(percentParam('_test', 0 / 0)).toBe('');
     // It accepts integers
-    expect(percentParam('test', 0)).toBe('test=0');
-    expect(percentParam('test', 33)).toBe('test=33');
-    expect(percentParam('test', 100)).toBe('test=100');
+    expect(percentParam('_test', 0)).toBe('_test=0');
+    expect(percentParam('_test', 33)).toBe('_test=33');
+    expect(percentParam('_test', 100)).toBe('_test=100');
     // It rounds values
-    expect(percentParam('test', Math.PI)).toBe('test=3');
-    expect(percentParam('test', 49.5001)).toBe('test=50');
+    expect(percentParam('_test', Math.PI)).toBe('_test=3');
+    expect(percentParam('_test', 49.5001)).toBe('_test=50');
     // It clamps values
-    expect(percentParam('test', -50)).toBe('test=0');
-    expect(percentParam('test', 150)).toBe('test=100');
+    expect(percentParam('_test', -50)).toBe('_test=0');
+    expect(percentParam('_test', 150)).toBe('_test=100');
   });
 
   test('stringParams', () => {
-    expect(stringParams('test', '')).toStrictEqual([]);
-    expect(stringParams('test', 'hello')).toStrictEqual(['test=hello']);
-    expect(stringParams('test', 'a/../b?c&d')).toStrictEqual(['test=a%2F..%2Fb%3Fc%26d']);
-    expect(stringParams('test', ['hello', 'beautiful', 'world'])).toStrictEqual([
-      'test=hello',
-      'test=beautiful',
-      'test=world',
+    expect(stringParams('_test', '')).toStrictEqual([]);
+    expect(stringParams('_test', 'hello')).toStrictEqual(['_test=hello']);
+    expect(stringParams('_test', 'a/../b?c&d')).toStrictEqual(['_test=a%2F..%2Fb%3Fc%26d']);
+    expect(stringParams('_test', ['hello', 'beautiful', 'world'])).toStrictEqual([
+      '_test=hello',
+      '_test=beautiful',
+      '_test=world',
     ]);
   });
 
   test('enumParam drops invalid options', () => {
     const options = ['yes', 'no', 'maybe'];
-    expect(enumParam('test', options)).toBe('');
-    expect(enumParam('test', options, 'yes')).toBe('test=yes');
-    expect(enumParam('test', options, 'nope')).toBe('');
-    expect(enumParam('test', options, 'maybe')).toBe('test=maybe');
+    expect(enumParam('_test', options)).toBe('');
+    expect(enumParam('_test', options, 'yes')).toBe('_test=yes');
+    expect(enumParam('_test', options, 'nope')).toBe('');
+    expect(enumParam('_test', options, 'maybe')).toBe('_test=maybe');
   });
 });
 
@@ -111,9 +111,9 @@ describe('buildParams', () => {
     ).toBe(
       `
         ?ctl=1
-        &devToolsHeight=100
+        &devtoolsheight=100
         &embed=1
-        &hideDevTools=1
+        &hidedevtools=1
         &hideExplorer=1
         &hideNavigation=1
         &showSidebar=1


### PR DESCRIPTION
We (well, I) introduced a regression in version 1.7.0 of the SDK by renaming the `hidedevtools` and `devtoolsheight` URL query parameters to `hideDevTools` and `devToolsHeight`.

See: https://github.com/stackblitz/core/commit/5e89b03320cd222f2b8cf19ae92820769f4671b5#diff-4db4b7030103b2f5677a33713b8c50bc15c70c96aafdf68adcd25f6f6a141a62L54-L65

While stackblitz.com does handle query parameters insensitive of case, StackBlitz EE may not (depending on the deployed version).

For backwards compatibility, those parameters should keep their original case.