### PR TITLE
Make project.description optional

### DIFF
--- a/src/interfaces.ts
+++ b/src/interfaces.ts
@@ -2,7 +2,7 @@ import type { PROJECT_TEMPLATES } from './constants';
 
 export interface Project {
   title: string;
-  description: string;
+  description?: string;
   /**
    * The project’s template name tells StackBlitz how to compile and run project files.
    *

--- a/test/e2e/embedVm.spec.ts
+++ b/test/e2e/embedVm.spec.ts
@@ -7,7 +7,6 @@ test('vm.getFsSnapshot and vm.applyFsDiff', async ({ page }) => {
   const project: Project = {
     title: 'Test Project',
     template: 'html',
-    description: '',
     files: {
       'index.html': `<h1>Hello World</h1>`,
       'styles.css': `body { color: lime }`,

--- a/test/unit/__snapshots__/generate.spec.ts.snap
+++ b/test/unit/__snapshots__/generate.spec.ts.snap
@@ -5,7 +5,7 @@ exports[`createProjectFrameHTML > generates a HTML document string 1`] = `
 <html>
 <head><title></title></head>
 <body>
-  <form method=\\"POST\\" style=\\"display:none!important;\\" action=\\"https://stackblitz.com/run?embed=1\\" id=\\"sb_run\\"><input type=\\"hidden\\" name=\\"project[title]\\" value=\\"Test Project\\"><input type=\\"hidden\\" name=\\"project[description]\\" value=\\"This is a test\\"><input type=\\"hidden\\" name=\\"project[template]\\" value=\\"javascript\\"><input type=\\"hidden\\" name=\\"project[files][package.json]\\" value=\\"{
+  <form method=\\"POST\\" style=\\"display:none!important;\\" action=\\"https://stackblitz.com/run?embed=1\\" id=\\"sb_run\\"><input type=\\"hidden\\" name=\\"project[title]\\" value=\\"Test Project\\"><input type=\\"hidden\\" name=\\"project[template]\\" value=\\"javascript\\"><input type=\\"hidden\\" name=\\"project[files][package.json]\\" value=\\"{
   &quot;dependencies&quot;: {&quot;cowsay&quot;: &quot;1.5.0&quot;}
 }\\"><input type=\\"hidden\\" name=\\"project[files][index.js]\\" value=\\"import cowsay from &#x27;cowsay&#x27;;
 console.log(cowsay(&#x27;Hello world!&#x27;));

--- a/test/unit/generate.spec.ts
+++ b/test/unit/generate.spec.ts
@@ -50,7 +50,7 @@ describe('createProjectForm', () => {
 
     // Check input values
     expect(value('project[title]')).toBe('My Test Project');
-    expect(value('project[description]')).toBe(project.description);
+    expect(value('project[description]')).toBe(undefined);
     expect(value('project[template]')).toBe(project.template);
     expect(value('project[dependencies]')).toBe(JSON.stringify(project.dependencies));
     expect(value('project[settings]')).toBe(JSON.stringify(project.settings));

--- a/test/unit/utils/project.ts
+++ b/test/unit/utils/project.ts
@@ -3,7 +3,6 @@ import type { Project } from '$src/index';
 export function getTestProject(project?: Partial<Project>): Project {
   return {
     title: 'Test Project',
-    description: 'This is a test',
     template: 'javascript',
     files: {
       'package.json': `{


### PR DESCRIPTION
When using the SDK's `embedProject` and `openProject` methods, which expect a project definition object, our TypeScript types require the `description` to be provided.

Turns out that the StackBlitz backend doesn't actually require a description.

In my own tests, having to come up with a description for a simple example, test or reproduction is often a chore. I've definitely used `description: ''` before as a workaround. I think we can get out of our users's way and make the description field optional.

What do you think?